### PR TITLE
Add env vars in docker-compose to override application properties

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ services:
     restart: always
     ports:
       - "8080:8080"
+    environment:
+      SPRING_DATASOURCE_URL: "jdbc:mysql://mysqldb:3306/bachelor"
+      SPRING_DATASOURCE_USERNAME: "karamitosnikos"
+      SPRING_DATASOURCE_PASSWORD: "karamitosnikos"
     depends_on:
       mysqldb: 
         condition: service_healthy


### PR DESCRIPTION
It is better / safer to use env vars in docker-compose.yml for the connection settings to MySQL. In this way, the values in application.properties can remain as used for local development